### PR TITLE
Add a dockerignore file to ignore non-source files.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+docker-compose.yml
+Dockerfile
+LICENSE
+manage
+README.md
+.gitignore


### PR DESCRIPTION
When manage script declares that `.` is the working directory, Docker is
doing a diff on all the files in `.` to see if it needs to remake
certain images.  Because we have typically made changes to the
Dockerfile before we do a build, it is *guaranteed* that there will be
some changes.  This causes certain directives/steps to be repeated
unnecessarily. It's also just good practice to have a Dockerignore to
avoid sending the entire repo over HTTP to the Docker server be it local
or remote.