### PR TITLE
Update documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ chmod +x /usr/local/bin/docker-compose
 ```bash
 curl -L https://github.com/bcgov/von-network/archive/master.zip > bcovrin.zip && \
     unzip bcovrin.zip && \
-    cd von-network-master
+    cd von-network-master && \
+    chmod a+w ./server/
 ```
 
 3. Map service port to 80 in docker-compose.yml


### PR DESCRIPTION
`./server` directory is mounted to into the we server container, and the server needs to be able to write to the directory.