### PR TITLE
Update README.md to docker-compose version 1.24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ GENESIS_URL=https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/so
     ```
 
     ```bash
-    curl -L https://github.com/docker/compose/releases/download/1.17.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+    curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
     ```
 
     ```bash


### PR DESCRIPTION
The current docker-compose version in readme does not support the --log-level flag included in the docker-compose commands in the manage script. Following the VPS instructions as they currently are (prior to this change) will cause ./manage start to fail (just hangs at the badly formed docker-compose command)