### PR TITLE
Updated dockerfile to include more source files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV LOG_LEVEL ${LOG_LEVEL:-info}
 ENV RUST_LOG ${RUST_LOG:-warning}
 
 ADD config ./config
-ADD server/requirements.txt server/
+ADD server ./server
+ADD scripts ./scripts
 RUN pip install --no-cache-dir -r server/requirements.txt
 
 ADD --chown=indy:indy indy_config.py /etc/indy/


### PR DESCRIPTION
@WadeBarnes this allows other projects to reference the von-network image without having to duplicate code. They would just specify in their `docker-compose,yml` something like this:
```
...
build:
      context: https://github.com/bcgov/von-network.git
      dockerfile: Dockerfile
...
```