### PR TITLE
change codenvy/che-ip image to eclipse/che-ip

### DIFF
--- a/manage
+++ b/manage
@@ -1,6 +1,6 @@
 #!/bin/bash
 export MSYS_NO_PATHCONV=1
-export DOCKERHOST=${APPLICATION_URL-$(docker run --rm --net=host codenvy/che-ip)}
+export DOCKERHOST=${APPLICATION_URL-$(docker run --rm --net=host eclipse/che-ip)}
 set -e
 
 SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"


### PR DESCRIPTION
the [`codenvy/che-ip`](https://hub.docker.com/r/codenvy/che-ip) image hasn't been updated since 3 years. The image is now maintained under [`eclipse/che-ip`](https://hub.docker.com/r/eclipse/che-ip). 

The `codenvy/che-ip` image was outputting two ip's (`178.128.255.156 10.18.0.6`) instead of one (`178.128.255.156`) on Ubuntu (not on macOS) which gave errors in the `generate_indy_pool_transactions` command. This is fixed by using the `eclipse/che-ip` image instead.

New image is tested on Ubuntu 18.04 and macOS