### PR TITLE
add ratification_ts to taa

### DIFF
--- a/config/sample_taa.json
+++ b/config/sample_taa.json
@@ -1,4 +1,5 @@
 {
   "version": "1.1",
-  "text": "TAA Goes *Here*\n\n- got it"
+  "text": "TAA Goes *Here*\n\n- got it",
+  "ratification_ts": 1597654073
 }

--- a/server/anchor.py
+++ b/server/anchor.py
@@ -243,7 +243,7 @@ class AnchorHandle:
 
         if aml_config and ("version" not in aml_config or "aml" not in aml_config):
             raise AnchorException("Invalid AML configuration")
-        if taa_config and ("version" not in taa_config or "text" not in taa_config):
+        if taa_config and ("version" not in taa_config or "text" not in taa_config or "ratification_ts" not in taa_config):
             raise AnchorException("Invalid TAA configuration")
 
         aml_methods = {}
@@ -284,7 +284,10 @@ class AnchorHandle:
         if taa_config:
             if not taa_found or taa_found["version"] != taa_config["version"]:
                 set_taa_req = await ledger.build_txn_author_agreement_request(
-                    self._did, taa_config["text"], taa_config["version"]
+                    self._did,
+                    taa_config["text"],
+                    taa_config["version"],
+                    taa_config["ratification_ts"]
                 )
                 await self.submit_request(set_taa_req, True)
                 LOGGER.info("Published TAA: %s", taa_config["version"])


### PR DESCRIPTION
Sinde indy node version 12 the `ratification_ts` parameter is required when submitting a new TAA. This PR adds the `ramification_ts` parameter to the taa config.

Following error is thrown when `ratification_ts` is not present:
```
ERROR: Cannot create transaction author agreement without a 'ratification_ts' field.
```