### PR TITLE
add pip install --upgrade pip in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV RUST_LOG ${RUST_LOG:-warning}
 
 ADD config ./config
 ADD server/requirements.txt server/
+RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r server/requirements.txt
 
 ADD --chown=indy:indy indy_config.py /etc/indy/


### PR DESCRIPTION
Hi,
I just wanted to add this super small change to make sure that during the build of local image current version of pip is being used.