### PR TITLE
indy-plenum has requirement pip<10.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV RUST_LOG ${RUST_LOG:-warning}
 
 ADD config ./config
 ADD server/requirements.txt server/
-RUN pip install --upgrade pip
+#RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r server/requirements.txt
 
 ADD --chown=indy:indy indy_config.py /etc/indy/


### PR DESCRIPTION
Signed-off-by: lsawicki <lukasz.sawicki@profondo.eu>

well, unfortunately the pip has to stay behind 10.0.0 version due to the pip.get_installed_distributions() not present in pip>=10.0.0