### PR TITLE
Error loading node status because JSONDecodeERROR

### DIFF
--- a/server/anchor.py
+++ b/server/anchor.py
@@ -628,12 +628,16 @@ class AnchorHandle:
 
         ret = []
         for node in node_aliases:
-            reply = json.loads(node_data[node])
-            if "result" not in reply:
+            try:
+                reply = json.loads(node_data[node])
+                if "result" not in reply:
+                    continue
+                data = reply["result"].get("data")
+                data["Node_info"]["Name"] = node
+                ret.append(data)
+            # Some of the nodes a not reachable.
+            except json.decoder.JSONDecodeError:
                 continue
-            data = reply["result"].get("data")
-            data["Node_info"]["Name"] = node
-            ret.append(data)
         return ret
 
     @property


### PR DESCRIPTION
Signed-off-by: Aberasturi <gabriel.aberasturi@versia.com>

I want to address #160 "Loading status" on "Validator Node Status" dashboard when node(s) stopped.

When we start VON-NETWORK and we check Ledger Browser we can see all the nodes up and running

![loading_satus_01](https://user-images.githubusercontent.com/39151755/128471073-0cbacf48-b7ae-4a71-b413-0ffb686f855a.png)

If we stop some of the Nodes Ledger Browser "Validator Node Status" doesn't show the other nodes status showing the message "Loading status".

![loading_satus_02](https://user-images.githubusercontent.com/39151755/128471076-97d159f4-63a2-4033-a63d-520840612241.png)

On ledger browser logs we get the error at "File "/home/indy/server/anchor.py", line 631, in validator_info" because "json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)".

```
reply = json.loads(node_data[node])
```



When `ledger get-validator-info` transaction is launched, on stopped nodes we haven't a "REPLY" (in json format) but "timeout" (string). For example:

```
"Node4":"timeout"
```

We solved the problem catching the exception and letting the not reachable nodes (timeouted) out of the response.

From

```
reply = json.loads(node_data[node])
```

To

```
  try:
      reply = json.loads(node_data[node])
      if "result" not in reply:
         continue
      data = reply["result"].get("data")
      data["Node_info"]["Name"] = node
      ret.append(data)
  # Some of the nodes a not reachable.
  except json.decoder.JSONDecodeError:
      continue
```

Now if we refresh Ledger Browser and we wait until `get-validator-info`  transcation finish, we can see the other started nodes.

![loading_satus_03](https://user-images.githubusercontent.com/39151755/128471078-ddd92380-d7af-4d54-b932-5617dead1d81.png)


**How to reproduce the problem:**

1. Start VON-NETWORK
2. Check Ledger Browser (http://localhost:9000)
3. Stop one of the Nodes.
```
docker stop [von_node2_1, von_node2_1, von_node3_1, von_node4_1
or
docker-compose stop [node1, node2, node3, node4]
```
4. Refresh Ledger Browser


```
USER@HOST:/von-network$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED              STATUS              PORTS                                                           NAMES
c5b12699b5f4        von-network-base    "bash -c './scripts/…"   About a minute ago   Up 59 seconds       0.0.0.0:9705-9706->9705-9706/tcp, :::9705-9706->9705-9706/tcp   von_node3_1
90f746c708d9        von-network-base    "bash -c './scripts/…"   About a minute ago   Up 59 seconds       0.0.0.0:9701-9702->9701-9702/tcp, :::9701-9702->9701-9702/tcp   von_node1_1
91130ccbfda4        von-network-base    "bash -c 'sleep 10; …"   About a minute ago   Up 59 seconds       0.0.0.0:9000->8000/tcp, :::9000->8000/tcp                       von_webserver_1
49dca286f8a1        von-network-base    "bash -c './scripts/…"   About a minute ago   Up 59 seconds       0.0.0.0:9703-9704->9703-9704/tcp, :::9703-9704->9703-9704/tcp   von_node2_1
8d2733665927        von-network-base    "bash -c './scripts/…"   About a minute ago   Up 59 seconds       0.0.0.0:9707-9708->9707-9708/tcp, :::9707-9708->9707-9708/tcp   von_node4_1
USER@HOST:/von-network$
```