### PR TITLE
Move sst_dump into the bcgovimages/von-image:node-1.12-4 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ RUN pip install --no-cache-dir -r server/requirements.txt
 
 ADD --chown=indy:indy indy_config.py /etc/indy/
 ADD --chown=indy:indy . $HOME
-RUN tar -xzf ./bin/sst_dump.tar.gz -C ./bin \
-    && rm ./bin/sst_dump.tar.gz \
-    && chmod +x ./bin/sst_dump
 
 RUN mkdir -p \
     $HOME/cli-scripts \

--- a/manage
+++ b/manage
@@ -78,7 +78,6 @@ usage () {
   backup [description] - Backup the current von-network environment.
           Creates a set of tar.gz archives of each of the environment's volumes.
           Backup sets are stored in a ./backup/date/time folder structure.
-
           Examples:
           $0 backup
           $0 backup "The description of my environment's current state."
@@ -105,8 +104,9 @@ usage () {
 
   debugVolume <volume> [volumeMountFolder] - Mount a named volume into a 'debug' instance of the `von-network-base` image with an interactive shell.
           Provides a containerized environment to perform analysis on the ledger databases and files.
-          The image conatins the RocksDB sst_dump tool an be used to verify and inspect the RocksDB database files; `*.sst` files.
-          For eaxmple the command 'find /debug_volume/ -name "*.sst" | xargs -I {} sst_dump --file={} --command=verify' can be used to do a quick
+          Starting with 'bcgovimages/von-image:node-1.12-4' the base image for von-network conatins the RocksDB sst_dump tool that can be used to verify
+          and inspect the RocksDB database files; `*.sst` files.
+          For example the command 'find /debug_volume/ -name "*.sst" | xargs -I {} sst_dump --file={} --command=verify' can be used to do a quick
           verification on all the database files once the container starts.
           Usage information for sst_dump can be found here; https://github.com/facebook/rocksdb/wiki/Administration-and-Data-Access-Tool
           Examples:


### PR DESCRIPTION
- Fix for build issue when the sst_dump binary is included at the `von-network` level.
- sst_dump is now included in the `bcgovimages/von-image:node-1.12-4` image.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>