### PR TITLE
Fix error in ledger transaction

### DIFF
--- a/server/anchor.py
+++ b/server/anchor.py
@@ -908,6 +908,9 @@ class LedgerCache:
             upd = "INSERT INTO terms ({}) VALUES ({})".format(
                 ", ".join(term_names), ", ".join("?" for _ in term_names)
             )
+            for k in term_names:
+                if isinstance(terms[k], dict):
+                    terms[k] = json.dumps(terms[k])
             terms_id = await self.insert(upd, tuple(terms[k] for k in term_names))
         await self.insert(
             "INSERT INTO transactions "


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

This fixes the exception when caching transactions, however the ATTRIB transaction on the ledger looks kind of weird, so not sure if the fix is required in aca-py.

The ledger ATTRIB transaction looks like:

```
  "txn": {
    "data": {
      "dest": "Vkd321e6ZXRspry48uzpH3",
      "raw": "{\"endpoint\":{\"endpoint\":{\"endpoint\":\"http://host.docker.internal:8020\",\"routingKeys\":[]}}}"
    },
...
  },
```