### PR TITLE
Relax object structure requirements for creddef to avoid browser error

### DIFF
--- a/server/anchor.py
+++ b/server/anchor.py
@@ -102,7 +102,7 @@ def format_validator_info(node_data):
             else:
                 data = {"Node_info": {"Name": node}, "error": "unknown error"}
         ret.append(data)
-    
+
     return ret
 
 
@@ -686,7 +686,7 @@ def txn_extract_terms(txn_json):
 
         elif txntype == "102":
             # CRED_DEF
-            result["data"] = " ".join(txn["data"]["data"]["primary"]["r"].keys())
+            result["data"] = " ".join(txn["data"]["data"]["primary"].keys())
 
     return txntype, result, ledger_size
 


### PR DESCRIPTION
Fixes #256 

Based on @andrewwhitehead comments this should allow for a more flexible set of structures in the creddef block.

@WadeBarnes we will need to deploy this before the workshop, logged https://github.com/bcgov/DITP-DevOps/issues/76 to track the work.