### PR TITLE
Add support for setting indy-node log level.

### DIFF
--- a/indy_config.py
+++ b/indy_config.py
@@ -1,3 +1,6 @@
+import os
+import logging
+
 NETWORK_NAME = 'sandbox'
 
 LEDGER_DIR = '/home/indy/ledger'
@@ -10,3 +13,5 @@ NODE_INFO_DIR = LEDGER_DIR
 
 CLI_BASE_DIR = '/home/indy/.indy-cli/'
 CLI_NETWORK_DIR = '/home/indy/.indy-cli/networks'
+
+logLevel = getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper())


### PR DESCRIPTION
- Have the indy-node log level follow the setting for LOG_LEVEL, which is set and can be controlled through von-network on startup.
- Examples:
  - `./manage start --logs LOG_LEVEL=debug`
  - `./manage start --logs LOG_LEVEL=info`
  - `./manage start --logs LOG_LEVEL=error`