### PR TITLE
Add workaround for Arm based MACs

### DIFF
--- a/manage
+++ b/manage
@@ -1,5 +1,14 @@
 #!/bin/bash
 export MSYS_NO_PATHCONV=1
+
+# Set default platform to linux/amd64 when running on Arm based MAC since there are no arm based images available currently.
+if [[ $OSTYPE == 'darwin'* ]]; then
+  architecture=$(uname -m)
+  if [[ "${architecture}" == 'arm'* ]] || [[ "${architecture}" == 'aarch'* ]]; then
+    export DOCKER_DEFAULT_PLATFORM=linux/amd64
+  fi
+fi
+
 # getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
 . /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))"
 export DOCKERHOST=$(getDockerHost)


### PR DESCRIPTION
- Auto-detect Arm based MAC and set `DOCKER_DEFAULT_PLATFORM=linux/amd64` to ensure docker uses amd64 emulation and uses the available base images.
- This is required since there are no Arm based base images for the project currently.