### PR TITLE
Add support for linking to an IndyScan instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,13 @@ The node pool can have a trust anchor write a did for you. That feature is avail
 It is possible to customize some of the aspects of the Ledger Browser at run-time, by using the following environment variables:
 
 - `REGISTER_NEW_DIDS`: if set to `True`, it will enable the user interface allowing new identity owners to write a DID to the ledger. It defaults to `False`.
-- `LEDGER_INSTANCE_NAME`: the name of the ledger instance the Ledger Brwoser is connected to. Defaults to `Ledger Browser`.
+- `LEDGER_INSTANCE_NAME`: the name of the ledger instance the Ledger Browser is connected to. Defaults to `Ledger Browser`.
 - `INFO_SITE_URL`: a URL that will be displayed in the header, and can be used to reference another external website containing details/resources on the current ledger browser instance.
 - `INFO_SITE_TEXT`: the display text used for the `INFO_SITE_URL`. If not specified, it will default to the value set for `INFO_SITE_URL`.
 - `WEB_ANALYTICS_SCRIPT`: the JavaScript code used by web analytics servers. Populate this environment variable if you want to track the usage of your site with Matomo, Google Analytics or any other JavaScript based trackers. Include the whole ```<script type="text/javascript">...</script>``` tag, ensuring quotes are escaped properly for your command-line interpreter (e.g.: bash, git bash, etc.).
 - `LEDGER_CACHE_PATH`: if set, it will instruct the ledger to create an on-disk cache, rather than in-memory.  The image supplies a folder for this purpose; `$HOME/.indy_client/ledger-cache`.  The file should be placed into this directory (e.g.: `/home/indy/.indy-client/ledger-cache/ledger_cache_file` or `$HOME/.indy_client/ledger-cache/ledger_cache_file`).
+- `INDY_SCAN_URL`: the URL to the external IndyScan ledger browser instance for the network.  This will replace the links to the builtin ledger browser tools.
+- `INDY_SCAN_TEXT`: the display text used for the `INDY_SCAN_URL`. If not specified, it will default to the value set for `INDY_SCAN_URL`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,16 @@ It is possible to customize some of the aspects of the Ledger Browser at run-tim
 - `INDY_SCAN_URL`: the URL to the external IndyScan ledger browser instance for the network.  This will replace the links to the builtin ledger browser tools.
 - `INDY_SCAN_TEXT`: the display text used for the `INDY_SCAN_URL`. If not specified, it will default to the value set for `INDY_SCAN_URL`.
 
+## Using IndyScan with VON Network
+
+[IndyScan](https://github.com/Patrik-Stas/indyscan) is production level transaction explorer for Hyperledger Indy networks.  It's a great tool for exploring and searching through the transactions on the various ledgers.
+
+You might be asking...  Why would I want to use IndyScan with `von-network`, when `von-network` has a built-in ledger browser?
+
+The short answer is performance at scale.  The built-in ledger browser works great for most local development purposes.  However, it starts running into performance issues when your instance contains over 100,000 transactions.  IndyScan on the other hand is backed by Elasticsearch and can easily scale well beyond that limitation.  So if you're hosting an instance of `von-network` for your organization to use for testing, like BC Gov does with [BCovrin Test](http://test.bcovrin.vonx.io/), you'll want to look into switching over to IndyScan as your ledger browser.
+
+To use IndyScan as your ledger browser for `von-network`, you're responsible for setting up and hosting your own instance of IndyScan.  Please refer to the [IndyScan](https://github.com/Patrik-Stas/indyscan) repository for information on how to accomplish this.  Once your IndyScan instance is up and running you can configure your `von-network` instance to provide a link to it on the main page by using the `INDY_SCAN_URL` and `INDY_SCAN_TEXT` variables described in the previous section.  The link to your IndyScan instance will replace the links to `von-network`'s built in ledger browser tools.
+
 ## Contributing
 
 **Pull requests are always welcome!**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       - WEB_ANALYTICS_SCRIPT=${WEB_ANALYTICS_SCRIPT}
       - INFO_SITE_TEXT=${INFO_SITE_TEXT}
       - INFO_SITE_URL=${INFO_SITE_URL}
+      - INDY_SCAN_URL=${INDY_SCAN_URL}
+      - INDY_SCAN_TEXT=${INDY_SCAN_TEXT}
     networks:
       - von
     ports:

--- a/server/server.py
+++ b/server/server.py
@@ -39,6 +39,8 @@ LOGGER.info(
 
 INFO_SITE_URL = os.getenv("INFO_SITE_URL")
 INFO_SITE_TEXT = os.getenv("INFO_SITE_TEXT") or os.getenv("INFO_SITE_URL")
+INDY_SCAN_URL = os.getenv("INDY_SCAN_URL")
+INDY_SCAN_TEXT = os.getenv("INDY_SCAN_TEXT") or os.getenv("INDY_SCAN_URL")
 
 APP = web.Application()
 aiohttp_jinja2.setup(APP, loader=jinja2.FileSystemLoader("./static"))
@@ -56,6 +58,8 @@ async def index(request):
         "WEB_ANALYTICS_SCRIPT": WEB_ANALYTICS_SCRIPT,
         "INFO_SITE_TEXT": INFO_SITE_TEXT,
         "INFO_SITE_URL": INFO_SITE_URL,
+        "INDY_SCAN_URL": INDY_SCAN_URL,
+        "INDY_SCAN_TEXT": INDY_SCAN_TEXT,
     }
 
 

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -93,34 +93,11 @@
             </p>
           </div>
         </div>
+        {% endraw %}
 
-        <div class="panel panel-default panel-ledger-status" style="display: none" v-show="ready">
-          <div class="panel-heading">
-            <h2>
-              <span class="fa fa-sitemap"></span>
-              Ledger State
-            </h2>
-          </div>
-          <div class="panel-body">
-            <div class="panel panel-node" v-if="syncing">
-              <div class="panel-body loading">
-                <p>
-                  <span class="fa fa-info-circle"></span> Fetching transactions
-                </p>
-              </div>
-            </div>
-            <p>
-              View the state of the ledgers:
-            </p>
-            <p>
-              <a href="/browse/domain" class="tool"><span class="fa fa-chevron-right left"></span>Domain</a>
-              <br>
-              <a href="/browse/pool" class="tool"><span class="fa fa-chevron-right left"></span>Pool</a>
-              <br>
-              <a href="/browse/config" class="tool"><span class="fa fa-chevron-right left"></span>Config</a>
-            </p>
-          </div>
-        </div>
+        {% include 'ledger_state.html' %}
+
+        {% raw %}
       </div>
 
       <aside class="col-tools" style="display: none" v-show="ready">

--- a/server/static/ledger_state.html
+++ b/server/static/ledger_state.html
@@ -1,0 +1,31 @@
+<div class="panel panel-default panel-ledger-status" style="display: none" v-show="ready">
+    <div class="panel-heading">
+        <h2>
+            <span class="fa fa-sitemap"></span>
+            Ledger State
+        </h2>
+    </div>
+    <div class="panel-body">
+        <div class="panel panel-node" v-if="syncing">
+            <div class="panel-body loading">
+                <p>
+                    <span class="fa fa-info-circle"></span> Fetching transactions
+                </p>
+            </div>
+        </div>
+        <p>
+            View the state of the ledgers:
+        </p>
+        <p>
+            {% if INDY_SCAN_URL %}
+            <a href="{{ INDY_SCAN_URL }}" class="tool" target="_blank"><span class="fa fa-chevron-right left"></span>{{ INDY_SCAN_TEXT }} <i class="fa fa-external-link"></i></a>
+            {% else %}
+            <a href="/browse/domain" class="tool"><span class="fa fa-chevron-right left"></span>Domain</a>
+            <br>
+            <a href="/browse/pool" class="tool"><span class="fa fa-chevron-right left"></span>Pool</a>
+            <br>
+            <a href="/browse/config" class="tool"><span class="fa fa-chevron-right left"></span>Config</a>
+            {% endif %}
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
The link to `INDY_SCAN_URL` is opened in a separate tab.

Example cmd line:
```
./manage start "INDY_SCAN_URL=http://localhost:3707/home/BCOVRIN_TEST" "INDY_SCAN_TEXT=BCovrin Scan"
```

UI Examples:

With `INDY_SCAN_URL` and `INDY_SCAN_TEXT` set:
![image](https://github.com/bcgov/von-network/assets/10504350/06e76778-4865-47d0-8750-fd8bd5411075)

With just `INDY_SCAN_URL` set:
![image](https://github.com/bcgov/von-network/assets/10504350/ad5f12b6-f9c4-4f45-a9ac-fda044c1559f)

With neither `INDY_SCAN_URL` or `INDY_SCAN_TEXT` set:
![image](https://github.com/bcgov/von-network/assets/10504350/a589c750-9375-4cf7-807d-5d543be3dadb)
