### PR TITLE
Refine dependabot configuration for github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions
+  #  - Group all updates into a single PR
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: 01:00
+      timezone: Canada/Pacific
+    groups:
+      all-actions:
+        patterns: [ "*" ]
 
   # Maintain dependencies for Python packages
   - package-ecosystem: pip


### PR DESCRIPTION
- Update weekly, Monday at 1am Pacific.
- Group all updates into a single PR.