### PR TITLE
Added support for changing default nodes ports

### DIFF
--- a/bin/von_generate_transactions
+++ b/bin/von_generate_transactions
@@ -17,6 +17,8 @@ usage () {
         Specify the ip address to use in the genesis transaction file.
     -s <ip addresses>
         Specify a comma delimited list of addresses to use in the genesis transaction file.
+    -p <ip ports>
+        Specify a comma delimited list of ports (2 for each ip) to use in the genesis transaction file.
     -n <node number>
         Specify the number to use for the given node.
     -h
@@ -25,6 +27,7 @@ usage () {
     Examples:
         $0 -i x.x.x.x -n y
         $0 -s "a.a.a.a,b.b.b.b,c.c.c.c,d.d.d.d" -n x
+        $0 -s "a.a.a.a,b.b.b.b,c.c.c.c,d.d.d.d" -p "a1,a2,b1,b2,c1,c2,d1,d2" -n x
 
         Use with Docker Compose:
         export DOCKERHOST=x.x.x.x
@@ -33,12 +36,13 @@ EOF
 exit 1
 }
 
-options=':i:s:n:h'
+options=':i:s:p:n:h'
 while getopts $options option
 do
     case $option in
         i  ) ipAddress=$OPTARG;;
         s  ) ipAddresses=$OPTARG;;
+        p  ) ipPorts=$OPTARG;;
         n  ) nodeNum=$OPTARG;;
         h  ) usage; exit;;
         \? ) echo -e "Unknown option: -$OPTARG" >&2; exit 1;;
@@ -81,10 +85,14 @@ else
     exit 1
 fi
 
+
 echo -e \\n\\n"================================================================================================"
 echo -e "Generating genesis transaction file:"
 echo -e "nodeArg: ${nodeArg}"
 echo -e "ipAddresses: ${ipsArg}"
+if [ ! -z "$ipPorts" ]; then
+    echo -e "ipPorts: ${ipPorts}"
+fi
 echo -e "genesisFilePath: ${genesisFilePath}"
 echo -e "------------------------------------------------------------------------------------------------"
 # Use supplied IP address
@@ -104,6 +112,37 @@ generate_indy_pool_transactions \
 echo -e \\n"------------------------------------------------------------------------------------------------"
 echo -e "Generated genesis transaction file; ${genesisFilePath}"\\n
 cat ${genesisFilePath}
+
+if [ ! -z "$ipPorts" ]; then
+    # Define the default and new port lists
+    ipPortsDefaults="9701,9702,9703,9704,9705,9706,9707,9708"
+
+    # Convert the comma-separated strings into arrays
+    IFS=',' read -r -a defaultPortsArray <<< "$ipPortsDefaults"
+    IFS=',' read -r -a newPortsArray <<< "$ipPorts"
+    
+    # Build the sed commands
+    sedComand=""
+
+    # Loop over both arrays and replace default ports with new ports
+    for (( i=0; i<${#newPortsArray[@]}; i+=2 )); do
+        # Replace the pair of default ports with new ports
+        defaultNodePort="${defaultPortsArray[i]}"
+        defaultClientPort="${defaultPortsArray[i+1]}"
+        
+        newNodePort="${newPortsArray[i]}"
+        newClientPort="${newPortsArray[i+1]}"
+
+        echo -e "cat ${genesisFilePath} | sed \"s~:$defaultNodePort,~:$newNodePort,~g\" | sed \"s~:$defaultClientPort,~:$newClientPort,~g\" > ${genesisFilePath}.tmp"
+        cat ${genesisFilePath} | sed "s~:$defaultNodePort,~:$newNodePort,~g" | sed "s~:$defaultClientPort,~:$newClientPort,~g" > ${genesisFilePath}.tmp
+        cat ${genesisFilePath}.tmp > ${genesisFilePath}
+        rm ${genesisFilePath}.tmp
+    done
+
+    echo -e \\n"------------------------------------------------------------------------------------------------"
+    echo -e "Updated genesis transaction file; ${genesisFilePath}"\\n
+    cat ${genesisFilePath}
+fi
 
 if [ ! -z "$remapPorts" ]; then
     echo -e \\n"------------------------------------------------------------------------------------------------"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       - IP=${IP}
       - IPS=${IPS}
+      - NODE_PORTS=${NODE1_PORT1:-9701},${NODE1_PORT2:-9702},${NODE2_PORT1:-9703},${NODE2_PORT2:-9704},${NODE3_PORT1:-9705},${NODE3_PORT2:-9706},${NODE4_PORT1:-9707},${NODE4_PORT2:-9708}
       - DOCKERHOST=${DOCKERHOST}
       - LOG_LEVEL=${LOG_LEVEL}
       - RUST_LOG=${RUST_LOG}
@@ -80,21 +81,22 @@ services:
   #
   nodes:
     image: von-network-base
-    command: ./scripts/start_nodes.sh
+    command: ./scripts/start_nodes.sh ${NODE1_PORT1:-9701} ${NODE1_PORT2:-9702} ${NODE2_PORT1:-9703} ${NODE2_PORT2:-9704} ${NODE3_PORT1:-9705} ${NODE3_PORT2:-9706} ${NODE4_PORT1:-9707} ${NODE4_PORT2:-9708}
     networks:
       - von
     ports:
-      - 9701:9701
-      - 9702:9702
-      - 9703:9703
-      - 9704:9704
-      - 9705:9705
-      - 9706:9706
-      - 9707:9707
-      - 9708:9708
+      - ${NODE1_EXPOSED_PORT1:-${NODE1_PORT1:-9701}}:${NODE1_PORT1:-9701}
+      - ${NODE1_EXPOSED_PORT2:-${NODE1_PORT2:-9702}}:${NODE1_PORT2:-9702}
+      - ${NODE2_EXPOSED_PORT1:-${NODE2_PORT1:-9703}}:${NODE2_PORT1:-9703}
+      - ${NODE2_EXPOSED_PORT2:-${NODE2_PORT2:-9704}}:${NODE2_PORT2:-9704}
+      - ${NODE3_EXPOSED_PORT1:-${NODE3_PORT1:-9705}}:${NODE3_PORT1:-9705}
+      - ${NODE3_EXPOSED_PORT2:-${NODE3_PORT2:-9706}}:${NODE3_PORT2:-9706}
+      - ${NODE4_EXPOSED_PORT1:-${NODE4_PORT1:-9707}}:${NODE4_PORT1:-9707}
+      - ${NODE4_EXPOSED_PORT2:-${NODE4_PORT2:-9708}}:${NODE4_PORT2:-9708}
     environment:
       - IP=${IP}
       - IPS=${IPS}
+      - NODE_PORTS=${NODE1_PORT1:-9701},${NODE1_PORT2:-9702},${NODE2_PORT1:-9703},${NODE2_PORT2:-9704},${NODE3_PORT1:-9705},${NODE3_PORT2:-9706},${NODE4_PORT1:-9707},${NODE4_PORT2:-9708}
       - DOCKERHOST=${DOCKERHOST}
       - LOG_LEVEL=${LOG_LEVEL}
       - RUST_LOG=${RUST_LOG}
@@ -103,15 +105,16 @@ services:
 
   node1:
     image: von-network-base
-    command: ./scripts/start_node.sh 1
+    command: ./scripts/start_node.sh 1 ${NODE1_PORT1:-9701} ${NODE1_PORT2:-9702}
     networks:
       - von
     ports:
-      - 9701:9701
-      - 9702:9702
+      - ${NODE1_EXPOSED_PORT1:-${NODE1_PORT1:-9701}}:${NODE1_PORT1:-9701}
+      - ${NODE1_EXPOSED_PORT2:-${NODE1_PORT2:-9702}}:${NODE1_PORT2:-9702}
     environment:
       - IP=${IP}
       - IPS=${IPS}
+      - NODE_PORTS=${NODE1_PORT1:-9701},${NODE1_PORT2:-9702},${NODE2_PORT1:-9703},${NODE2_PORT2:-9704},${NODE3_PORT1:-9705},${NODE3_PORT2:-9706},${NODE4_PORT1:-9707},${NODE4_PORT2:-9708}
       - DOCKERHOST=${DOCKERHOST}
       - LOG_LEVEL=${LOG_LEVEL}
       - RUST_LOG=${RUST_LOG}
@@ -120,15 +123,16 @@ services:
 
   node2:
     image: von-network-base
-    command: ./scripts/start_node.sh 2
+    command: ./scripts/start_node.sh 2 ${NODE2_PORT1:-9703} ${NODE2_PORT2:-9704}
     networks:
       - von
     ports:
-      - 9703:9703
-      - 9704:9704
+      - ${NODE2_EXPOSED_PORT1:-${NODE2_PORT1:-9703}}:${NODE2_PORT1:-9703}
+      - ${NODE2_EXPOSED_PORT2:-${NODE2_PORT2:-9704}}:${NODE2_PORT2:-9704}
     environment:
       - IP=${IP}
       - IPS=${IPS}
+      - NODE_PORTS=${NODE1_PORT1:-9701},${NODE1_PORT2:-9702},${NODE2_PORT1:-9703},${NODE2_PORT2:-9704},${NODE3_PORT1:-9705},${NODE3_PORT2:-9706},${NODE4_PORT1:-9707},${NODE4_PORT2:-9708}
       - DOCKERHOST=${DOCKERHOST}
       - LOG_LEVEL=${LOG_LEVEL}
       - RUST_LOG=${RUST_LOG}
@@ -137,15 +141,16 @@ services:
 
   node3:
     image: von-network-base
-    command: ./scripts/start_node.sh 3
+    command: ./scripts/start_node.sh 3 ${NODE3_PORT1:-9705} ${NODE3_PORT2:-9706}
     networks:
       - von
     ports:
-      - 9705:9705
-      - 9706:9706
+      - ${NODE3_EXPOSED_PORT1:-${NODE3_PORT1:-9705}}:${NODE3_PORT1:-9705}
+      - ${NODE3_EXPOSED_PORT2:-${NODE3_PORT2:-9706}}:${NODE3_PORT2:-9706}
     environment:
       - IP=${IP}
       - IPS=${IPS}
+      - NODE_PORTS=${NODE1_PORT1:-9701},${NODE1_PORT2:-9702},${NODE2_PORT1:-9703},${NODE2_PORT2:-9704},${NODE3_PORT1:-9705},${NODE3_PORT2:-9706},${NODE4_PORT1:-9707},${NODE4_PORT2:-9708}
       - DOCKERHOST=${DOCKERHOST}
       - LOG_LEVEL=${LOG_LEVEL}
       - RUST_LOG=${RUST_LOG}
@@ -154,15 +159,16 @@ services:
 
   node4:
     image: von-network-base
-    command: ./scripts/start_node.sh 4
+    command: ./scripts/start_node.sh 4 ${NODE4_PORT1:-9707} ${NODE4_PORT2:-9708}
     networks:
       - von
     ports:
-      - 9707:9707
-      - 9708:9708
+      - ${NODE4_EXPOSED_PORT1:-${NODE4_PORT1:-9707}}:${NODE4_PORT1:-9707}
+      - ${NODE4_EXPOSED_PORT2:-${NODE4_PORT2:-9708}}:${NODE4_PORT2:-9708}
     environment:
       - IP=${IP}
       - IPS=${IPS}
+      - NODE_PORTS=${NODE1_PORT1:-9701},${NODE1_PORT2:-9702},${NODE2_PORT1:-9703},${NODE2_PORT2:-9704},${NODE3_PORT1:-9705},${NODE3_PORT2:-9706},${NODE4_PORT1:-9707},${NODE4_PORT2:-9708}
       - DOCKERHOST=${DOCKERHOST}
       - LOG_LEVEL=${LOG_LEVEL}
       - RUST_LOG=${RUST_LOG}

--- a/manage
+++ b/manage
@@ -356,6 +356,7 @@ function initEnv() {
     fi
   fi
   export IP="$IP" IPS="$IPS"
+  export NODE_PORTS="$NODE_PORTS"
 
   export LEDGER_SEED=${LEDGER_SEED}
 

--- a/scripts/init_genesis.sh
+++ b/scripts/init_genesis.sh
@@ -2,13 +2,21 @@
 
 set -e
 
+PARAMS=""
+
 if [ ! -z "$IPS" ]; then
-    echo von_generate_transactions -s "$IPS" -n "$NODE_NUM"
-    von_generate_transactions -s "$IPS" -n "$NODE_NUM"
+    PARAMS+=" -s \"$IPS\""
 elif [ ! -z "$IP" ]; then
-    echo von_generate_transactions -i "$IP" -n "$NODE_NUM"
-    von_generate_transactions -i "$IP" -n "$NODE_NUM"
-else
-    echo von_generate_transactions -n "$NODE_NUM"
-    von_generate_transactions -n "$NODE_NUM"
+    PARAMS+=" -s \"$IP\""
 fi
+
+if [ ! -z "$NODE_PORTS" ]; then
+    PARAMS+=" -p $NODE_PORTS"
+fi
+
+if [ ! -z "$NODE_NUM" ]; then
+    PARAMS+=" -n $NODE_NUM"
+fi
+
+echo von_generate_transactions $PARAMS
+von_generate_transactions $PARAMS

--- a/scripts/start_node.sh
+++ b/scripts/start_node.sh
@@ -4,8 +4,16 @@ set -e
 
 HOST="${HOST:-0.0.0.0}"
 export NODE_NUM="${1}"
-START_PORT="9700"
-NODE_PORT=$((START_PORT + ( NODE_NUM * 2 ) - 1 ))
+DEFAULT_START_PORT="9700"
+NODE_PORT1="${2}"
+NODE_PORT2="${3}"
+
+if [[ -z "$NODE_PORT1" ]] ; then
+    NODE_PORT1=$(( DEFAULT_START_PORT + ( NODE_NUM * 2 ) - 1 ))
+fi
+if [[ -z "$NODE_PORT2" ]] ; then
+    NODE_PORT2=$(( NODE_PORT1 + 1 ))
+fi
 
 if [ ! -d "/home/indy/ledger/sandbox/keys" ]; then
     echo "Ledger does not exist - Creating..."
@@ -13,5 +21,5 @@ if [ ! -d "/home/indy/ledger/sandbox/keys" ]; then
 fi
 
 
-echo start_indy_node "Node""$NODE_NUM" $HOST $NODE_PORT $HOST $(( NODE_PORT + 1 ))
-start_indy_node "Node""$NODE_NUM" $HOST $NODE_PORT $HOST $(( NODE_PORT + 1 ))
+echo start_indy_node "Node""$NODE_NUM" $HOST $NODE_PORT1 $HOST $NODE_PORT2
+start_indy_node "Node""$NODE_NUM" $HOST $NODE_PORT1 $HOST $NODE_PORT2

--- a/scripts/start_nodes.sh
+++ b/scripts/start_nodes.sh
@@ -3,8 +3,46 @@
 set -e
 
 HOST="${HOST:-0.0.0.0}"
-START_PORT="9700"
 export NODE_NUM="1 2 3 4"
+DEFAULT_START_PORT="9700"
+
+NODE1_PORT1="${1}"
+NODE1_PORT2="${2}"
+if [[ -z "$NODE1_PORT1" ]] ; then
+    NODE1_PORT1=$(( DEFAULT_START_PORT + ( 1 * 2 ) - 1 ))
+fi
+if [[ -z "$NODE1_PORT2" ]] ; then
+    NODE1_PORT2=$(( NODE1_PORT1 + 1 ))
+fi
+
+NODE2_PORT1="${3}"
+NODE2_PORT2="${4}"
+if [[ -z "$NODE2_PORT1" ]] ; then
+    NODE2_PORT1=$(( DEFAULT_START_PORT + ( 2 * 2 ) - 1 ))
+fi
+if [[ -z "$NODE2_PORT2" ]] ; then
+    NODE2_PORT2=$(( NODE2_PORT1 + 1 ))
+fi
+
+NODE3_PORT1="${5}"
+NODE3_PORT2="${6}"
+if [[ -z "$NODE3_PORT1" ]] ; then
+    NODE3_PORT1=$(( DEFAULT_START_PORT + ( 3 * 2 ) - 1 ))
+fi
+if [[ -z "$NODE3_PORT2" ]] ; then
+    NODE3_PORT2=$(( NODE3_PORT1 + 1 ))
+fi
+
+NODE4_PORT1="${7}"
+NODE4_PORT2="${8}"
+if [[ -z "$NODE4_PORT1" ]] ; then
+    NODE4_PORT1=$(( DEFAULT_START_PORT + ( 4 * 2 ) - 1 ))
+fi
+if [[ -z "$NODE4_PORT2" ]] ; then
+    NODE4_PORT2=$(( NODE4_PORT1 + 1 ))
+fi
+
+
 
 if [ ! -d "/home/indy/ledger/sandbox/keys" ]; then
     echo "Ledger does not exist - Creating..."
@@ -30,25 +68,25 @@ childlogdir = /tmp
 strip_ansi = false
 
 [program:node1]
-command=start_indy_node Node1 $HOST 9701 $HOST 9702
+command=start_indy_node Node1 $HOST $NODE1_PORT1 $HOST $NODE1_PORT2
 directory=/home/indy
 stdout_logfile=/tmp/node1.log
 stderr_logfile=/tmp/node1.log
 
 [program:node2]
-command=start_indy_node Node2 $HOST 9703 $HOST 9704
+command=start_indy_node Node2 $HOST $NODE2_PORT1 $HOST $NODE2_PORT2
 directory=/home/indy
 stdout_logfile=/tmp/node2.log
 stderr_logfile=/tmp/node2.log
 
 [program:node3]
-command=start_indy_node Node3 $HOST 9705 $HOST 9706
+command=start_indy_node Node3 $HOST $NODE3_PORT1 $HOST $NODE3_PORT2
 directory=/home/indy
 stdout_logfile=/tmp/node3.log
 stderr_logfile=/tmp/node3.log
 
 [program:node4]
-command=start_indy_node Node4 $HOST 9707 $HOST 9708
+command=start_indy_node Node4 $HOST $NODE4_PORT1 $HOST $NODE4_PORT2
 directory=/home/indy
 stdout_logfile=/tmp/node4.log
 stderr_logfile=/tmp/node4.log


### PR DESCRIPTION
This is related to issue #283

Changed the following files
- bin/von_generate_transactions
    - New parameter for supplying ports of your preference
    - Code added to replace default ports on the generated genesis file
- dockercompose.yml
    - Added environment variables to allow default ports to be changed (`NODE1_PORT1`, `NODE1_PORT2`, `NODE2_PORT1`, `NODE2_PORT2` etc.)
- manage
    - Added exposed variable for `NODE_PORTS` just like the `IP` variable is exposed
- scripts/init_genesis.sh | scripts/start_node.sh | scripts/start_nodes.sh
    - Updated to pass the appropriate ports on `start_indy_node` and `von_generate_transactions` scripts
    