### PR TITLE
Revert rlp version to fix node startup issues.

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,6 +6,6 @@ aiosqlite~=0.17.0
 base58~=1.0.3
 indy_vdr~=0.3.4
 cchardet~=2.1.0
-rlp~=3.0.0
+rlp~=0.6.0
 supervisor~=4.0.4
 pynacl~=1.5.0


### PR DESCRIPTION
- Another indication we need to separate the browser and node images.