### PR TITLE
Add route timeout.

### DIFF
--- a/openshift/templates/ledger-browser/ledger-browser-deploy.yaml
+++ b/openshift/templates/ledger-browser/ledger-browser-deploy.yaml
@@ -65,6 +65,8 @@ objects:
         app: ${NAME}${SUFFIX}
         env: ${TAG_NAME}
         certbot-managed: ${CERTBOT_MANAGED_ROUTE}
+      annotations:
+        haproxy.router.openshift.io/timeout: 240s
     spec:
       host: ${FQDN_HOST_NAME}
       port:


### PR DESCRIPTION
- So the UI and API are given enough time to respond when a node is down.